### PR TITLE
hdl_graph_slam support

### DIFF
--- a/config/params_hdl_graph_slam.yaml
+++ b/config/params_hdl_graph_slam.yaml
@@ -1,0 +1,89 @@
+removert:
+
+  # @ NOTE: Recommended test regions and corresponding parameters
+  # - KITTI 09 [downsample_voxel_size: 0.05m, skips: 5, start idx: 1300, end idx: 1600] 
+  # - KITTI 03 [downsample_voxel_size: 0.05m, skips: 5, start idx: 0, end idx: 150] 
+
+  # 
+  isScanFileKITTIFormat: false
+  isDumpHdlGraphSlamFormat: true
+
+  # @ save option 
+  saveMapPCD: true 
+  saveCleanScansPCD: true
+  save_pcd_directory: "/home/daniil/Documents/removert/dump/" # replace to your path (please use an absolute path)
+
+
+  # @ sequence info (replace to your paths) 
+  #   please follow the KITTI odometry dataset's scan and pose formats (i.e., make them .bin and line-by-line corresponding se3 poses composed of 12 numbers)
+  sequence_scan_dir: "/home/daniil/Documents/removert/dump/"
+  sequence_pose_path: "/home/daniil/Documents/removert/dump/"
+
+  sequence_vfov: 50 # including upper and lower fovs, for example, KITTI's HDL64E is 2 + 24.9 ~ 27 deg. (so 25 + 25 = 50 is recommended because it is enough)
+  sequence_hfov: 360 # generally for targetting scanning LiDAR but a lidar having restricted hfov also just can use the 360 (because no point regions are considered in the algorithm)
+
+
+  # @ Sequence's BaseToLidar info
+  #ExtrinsicLiDARtoPoseBase: # this is for the KITTI (in the removert example, using SuMa poses written in the camera coord)
+  #    [-1.857e-03, -9.999e-01, -8.039e-03, -4.784e-03,
+  #     -6.481e-03,  8.0518e-03, -9.999e-01, -7.337e-02,
+  #      9.999e-01, -1.805e-03, -6.496e-03, -3.339e-01,
+  #      0.0,        0.0,        0.0,        1.0]
+  # @ If you use the lidar-itself odometry (e.g., from A-LOAM or using odometry saver https://github.com/SMRT-AIST/interactive_slam/wiki/Example2), 
+  #   use the below identity matrix, not the above KITTI pose setting (w.r.t the camera).
+  ExtrinsicLiDARtoPoseBase: [1.0, 0.0, 0.0, 0.0,
+                              0.0, 1.0, 0.0, 0.0,
+                              0.0, 0.0, 1.0, 0.0,
+                              0.0, 0.0, 0.0, 1.0]
+
+
+  # @ Sampling nodes 
+  use_keyframe_gap: false
+  keyframe_gap: 5 # i.e., 5 means every 5 frames // 5 is recommended for fast removing while preserving the static map's quality # if you make all scans clean, use this value = 1
+  # keyframe_gap: 2 # i.e., 5 means every 5 frames // 5 is recommended for fast removing while preserving the static map's quality # if you make all scans clean, use this value = 1
+
+  # use_keyframe_meter: false # TODO
+  # keyframe_meter: 2 # TODO, e.g., every 2 meters (using the given pose relative translations) 
+
+
+  # @ target region (scan idx range) when clean_for_all_scan is false 
+  #   means the removeter runs on all scans in a specified regions of a sequence 
+  #   it means we parse scans every <keyframe_gap> or <keyframe_gap_meter> meter within the idx range [start_idx, end_idx] 
+  #   but for a single batch, < 100 scans are recommended for the computation speed.
+  start_idx: 1300 # change this
+  end_idx: 1600 # change this
+
+
+  # @ Range image resolution
+  # the below is actually magnifier ratio (i.e., 5 means x5 resolution, the x1 means 1 deg x 1 deg per pixel)
+  # - recommend to use the first removing resolution's magnifier ratio should meet the seonsor vertical fov / number of rays 
+  #     - e.g., HDL 64E of KITTI dataset -> appx 25 deg / 64 ray ~ 0.4 deg per pixel -> the magnifier ratio = 1/0.4 = 2.5
+  #     - e.g., Ouster OS1-64 of MulRan dataset -> appx 45 deg / 64 ray ~ 0.7 deg per pixel -> the magnifier ratio = 1/0.7 = 1.4
+  # - recommend to use the first reverting resolution's magnifier ratio should lied in 1.0 to 1.5
+  remove_resolution_list: [1.25, 1.0] # for HDL 64E of KITTI dataset
+  # remove_resolution_list: [1.4, 1.1] # for Ouster OS1-64 of MulRan dataset
+  revert_resolution_list: [1.0, 0.9, 0.8, 0.7] # TODO
+
+
+  # @ Removert params 
+  # about density 
+  downsample_voxel_size: 0.05 # user parameter but recommend to use 0.05 to make sure an enough density (this value is related to the removing resolution's expected performance)
+
+  # about Static sensitivity (you need to tune these below two values, depends on the environement)
+  # - if you use a raw scan 
+  num_nn_points_within: 2 # how many - using higher, more strict static 
+  dist_nn_points_within: 0.1 # meter - using smaller, more strict static 
+
+  # about Static sensitivity (SC-LIO-SAM's feature cloud)
+  # - if you use a SC-LIO-SAM's feature cloud
+  # num_nn_points_within: 2 # how many - using higher, more strict static 
+  # dist_nn_points_within: 0.2 # meter - using smaller, more strict static 
+
+
+  # @ For faster
+  num_omp_cores: 16 # for faster map points projection (to make a map range image)
+
+  
+  # @ For visualization of range images (rviz -d removert_visualization.rviz)
+  rimg_color_min: 0.0 # meter
+  rimg_color_max: 20.0 # meter

--- a/include/removert/RosParamServer.h
+++ b/include/removert/RosParamServer.h
@@ -32,6 +32,7 @@ public:
 
     // sequence bin files
     bool isScanFileKITTIFormat_;
+    bool isDumpHdlGraphSlamFormat_;
 
     std::string sequence_scan_dir_;
     std::vector<std::string> sequence_scan_names_;

--- a/include/removert/utility.h
+++ b/include/removert/utility.h
@@ -150,4 +150,6 @@ double ROS_TIME(T msg)
 float pointDistance(PointType p);
 float pointDistance(PointType p1, PointType p2);
 
+Eigen::Matrix4d readPose(const std::string& filename);
+
 #endif

--- a/launch/run_hdl_graph_slam.launch
+++ b/launch/run_hdl_graph_slam.launch
@@ -1,0 +1,21 @@
+<launch>
+
+    <arg name="project" default="removert"/>
+
+    <!--- Run Rviz-->
+    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find removert)/launch/removert_visualization.rviz" />
+
+    <!-- Parameters -->
+    <rosparam file="$(find removert)/config/params_hdl_graph_slam.yaml" command="load" />
+
+    <!--- Removert -->
+    <!-- <node pkg="$(arg project)" type="$(arg project)_removert"   name="$(arg project)_removert"    output="screen" 	respawn="true"/> -->
+    <node pkg="$(arg project)" type="$(arg project)_removert"   name="$(arg project)_removert"   output="screen"/>
+
+    <!--- Run Rqt (show range images-->
+    <!-- <include file="$(find lio_sam)/launch/include/module_rviz.launch" /> -->
+
+    <!--- Run Rviz-->
+    <!-- <include file="$(find lio_sam)/launch/include/module_rviz.launch" /> -->
+
+</launch>

--- a/src/Removerter.cpp
+++ b/src/Removerter.cpp
@@ -312,15 +312,16 @@ void Removerter::mergeScansWithinGlobalCoord(
 
 void Removerter::octreeDownsampling(const pcl::PointCloud<PointType>::Ptr& _src, pcl::PointCloud<PointType>::Ptr& _to_save)
 {
+    ROS_WARN("%s", __PRETTY_FUNCTION__ );
     pcl::octree::OctreePointCloudVoxelCentroid<PointType> octree( kDownsampleVoxelSize );
     octree.setInputCloud(_src);
     octree.defineBoundingBox();
     octree.addPointsFromInputCloud();
-    pcl::octree::OctreePointCloudVoxelCentroid<PointType>::AlignedPointTVector centroids;
-    octree.getVoxelCentroids(centroids);
+    octree.getVoxelCentroids(_to_save->points);
 
-    // init current map with the downsampled full cloud 
-    _to_save->points.assign(centroids.begin(), centroids.end());    
+    ROS_DEBUG("Octree done.");
+
+    // init current map with the downsampled full cloud
     _to_save->width = 1; 
     _to_save->height = _to_save->points.size(); // make sure again the format of the downsampled point cloud 
     ROS_INFO_STREAM("\033[1;32m Downsampled pointcloud have: " << _to_save->points.size() << " points.\033[0m");   

--- a/src/Removerter.cpp
+++ b/src/Removerter.cpp
@@ -63,7 +63,6 @@ Removerter::Removerter()
 
 void Removerter::allocateMemory()
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     map_global_orig_.reset(new pcl::PointCloud<PointType>());
 
     map_global_curr_.reset(new pcl::PointCloud<PointType>());
@@ -93,7 +92,6 @@ Removerter::~Removerter(){}
 
 void Removerter::parseValidScanInfo( void )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     if (isDumpHdlGraphSlamFormat_) {
         sequence_valid_scan_paths_ = sequence_scan_paths_;
         sequence_valid_scan_names_ = sequence_scan_names_;
@@ -147,7 +145,6 @@ void Removerter::parseValidScanInfo( void )
 void Removerter::readValidScans( void )
 // for target range of scan idx 
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     const int cout_interval {10};
     int cout_counter {0};
 
@@ -190,7 +187,6 @@ std::pair<cv::Mat, cv::Mat> Removerter::map2RangeImg(const pcl::PointCloud<Point
                       const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov = 360] */
                       const std::pair<int, int> _rimg_size)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     const float kVFOV = _fov.first;
     const float kHFOV = _fov.second;
     
@@ -241,7 +237,6 @@ cv::Mat Removerter::scan2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan,
                       const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov = 360] */
                       const std::pair<int, int> _rimg_size)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     const float kVFOV = _fov.first;
     const float kHFOV = _fov.second;
     
@@ -292,7 +287,6 @@ void Removerter::mergeScansWithinGlobalCoord(
         const std::vector<Eigen::Matrix4d>& _scans_poses,
         pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // NOTE: _scans must be in local coord
     for(std::size_t scan_idx = 0 ; scan_idx < _scans.size(); scan_idx++)
     {
@@ -331,7 +325,6 @@ void Removerter::octreeDownsampling(const pcl::PointCloud<PointType>::Ptr& _src,
 
 void Removerter::makeGlobalMap( void )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // transform local to global and merging the scans 
     map_global_orig_->clear();
     map_global_curr_->clear();
@@ -378,7 +371,6 @@ void Removerter::makeGlobalMap( void )
 
 void Removerter::transformGlobalMapSubsetToLocal(int _base_scan_idx)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
     
     // global to local (global2local)
@@ -391,7 +383,6 @@ void Removerter::transformGlobalMapSubsetToLocal(int _base_scan_idx)
 
 void Removerter::transformGlobalMapToLocal(int _base_scan_idx)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
     
     // global to local (global2local)
@@ -404,7 +395,6 @@ void Removerter::transformGlobalMapToLocal(int _base_scan_idx)
 
 void Removerter::transformGlobalMapToLocal(int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
     
     // global to local (global2local)
@@ -419,7 +409,6 @@ void Removerter::transformGlobalMapToLocal(
     const pcl::PointCloud<PointType>::Ptr& _map_global, 
     int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
     
     // global to local (global2local)
@@ -432,7 +421,6 @@ void Removerter::transformGlobalMapToLocal(
 
 void Removerter::parseMapPointcloudSubsetUsingPtIdx( std::vector<int>& _point_indexes, pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save ) 
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // extractor
     pcl::ExtractIndices<PointType> extractor;
     boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
@@ -448,7 +436,6 @@ void Removerter::parseMapPointcloudSubsetUsingPtIdx( std::vector<int>& _point_in
 
 void Removerter::parseStaticMapPointcloudUsingPtIdx( std::vector<int>& _point_indexes ) 
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // extractor
     pcl::ExtractIndices<PointType> extractor;
     boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
@@ -464,7 +451,6 @@ void Removerter::parseStaticMapPointcloudUsingPtIdx( std::vector<int>& _point_in
 
 void Removerter::parseDynamicMapPointcloudUsingPtIdx( std::vector<int>& _point_indexes )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // extractor
     pcl::ExtractIndices<PointType> extractor;
     boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
@@ -480,7 +466,6 @@ void Removerter::parseDynamicMapPointcloudUsingPtIdx( std::vector<int>& _point_i
 
 void Removerter::saveCurrentStaticAndDynamicPointCloudGlobal( void )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     if( ! kFlagSaveMapPointcloud )
         return;
 
@@ -500,7 +485,6 @@ void Removerter::saveCurrentStaticAndDynamicPointCloudGlobal( void )
 
 void Removerter::saveCurrentStaticAndDynamicPointCloudLocal( int _base_node_idx )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     if( ! kFlagSaveMapPointcloud )
         return;
 
@@ -526,7 +510,6 @@ void Removerter::saveCurrentStaticAndDynamicPointCloudLocal( int _base_node_idx 
 std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdx
     (const cv::Mat& _scan_rimg, const cv::Mat& _diff_rimg, const cv::Mat& _map_rimg_ptidx)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     int num_dyna_points {0}; // TODO: tracking the number of dynamic-assigned points and decide when to stop removing (currently just fixed iteration e.g., [2.5, 2.0, 1.5])
 
     std::vector<int> dynamic_point_indexes;
@@ -556,7 +539,6 @@ std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdx
 
 void Removerter::takeGlobalMapSubsetWithinBall( int _center_scan_idx )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     Eigen::Matrix4d center_pose_se3 = scan_poses_.at(_center_scan_idx);
     PointType center_pose;
     center_pose.x = float(center_pose_se3(0, 3));
@@ -572,7 +554,6 @@ void Removerter::takeGlobalMapSubsetWithinBall( int _center_scan_idx )
 
 std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdxForEachScan( std::pair<int, int> _rimg_shape )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     std::vector<int> dynamic_point_indexes;
     // dynamic_point_indexes.reserve(100000);
     for(std::size_t idx_scan=0; idx_scan < scans_.size(); ++idx_scan) {            
@@ -624,7 +605,6 @@ std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdxForEachScan( 
 
 std::vector<int> Removerter::getStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes, int _num_all_points)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     std::vector<int> pt_idx_all = linspace<int>(0, _num_all_points, _num_all_points);
 
     std::set<int> pt_idx_all_set (pt_idx_all.begin(), pt_idx_all.end());
@@ -639,7 +619,6 @@ std::vector<int> Removerter::getStaticIdxFromDynamicIdx(const std::vector<int>& 
 
 std::vector<int> Removerter::getGlobalMapStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     int num_all_points = map_global_curr_->points.size();
     return getStaticIdxFromDynamicIdx(_dynamic_point_indexes, num_all_points);
 } // getGlobalMapStaticIdxFromDynamicIdx
@@ -648,7 +627,6 @@ std::vector<int> Removerter::getGlobalMapStaticIdxFromDynamicIdx(const std::vect
 
 void Removerter::saveCurrentStaticMapHistory(void)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // deep copy
     pcl::PointCloud<PointType>::Ptr map_global_curr_static (new pcl::PointCloud<PointType>);
     *map_global_curr_static = *map_global_curr_;  
@@ -660,7 +638,6 @@ void Removerter::saveCurrentStaticMapHistory(void)
 
 void Removerter::removeOnce( float _res_alpha )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // filter spec (i.e., a shape of the range image) 
     curr_res_alpha_ = _res_alpha;
 
@@ -693,7 +670,6 @@ void Removerter::removeOnce( float _res_alpha )
 
 void Removerter::revertOnce( float _res_alpha )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     std::pair<int, int> rimg_shape = resetRimgSize(kFOV, _res_alpha);
     float deg_per_pixel = 1.0 / _res_alpha;    
     ROS_INFO_STREAM("\033[1;32m Reverting starts with resolution: x" << _res_alpha << " (" << deg_per_pixel << " deg/pixel)\033[0m");   
@@ -708,7 +684,6 @@ void Removerter::revertOnce( float _res_alpha )
 void Removerter::parsePointcloudSubsetUsingPtIdx( const pcl::PointCloud<PointType>::Ptr& _ptcloud_orig,
             std::vector<int>& _point_indexes, pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save ) 
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // extractor
     pcl::ExtractIndices<PointType> extractor;
     boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
@@ -724,7 +699,6 @@ void Removerter::parsePointcloudSubsetUsingPtIdx( const pcl::PointCloud<PointTyp
 
 pcl::PointCloud<PointType>::Ptr Removerter::local2global(const pcl::PointCloud<PointType>::Ptr& _scan_local, int _scan_idx)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     Eigen::Matrix4d scan_pose = scan_poses_.at(_scan_idx);
 
     pcl::PointCloud<PointType>::Ptr scan_global(new pcl::PointCloud<PointType>());
@@ -736,7 +710,6 @@ pcl::PointCloud<PointType>::Ptr Removerter::local2global(const pcl::PointCloud<P
 
 pcl::PointCloud<PointType>::Ptr Removerter::global2local(const pcl::PointCloud<PointType>::Ptr& _scan_global, int _scan_idx)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     if (kSE3MatExtrinsicPoseBasetoLiDAR != Eigen::Matrix4d::Identity())
         return _scan_global;
     Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_scan_idx);
@@ -751,7 +724,6 @@ pcl::PointCloud<PointType>::Ptr Removerter::global2local(const pcl::PointCloud<P
 std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr> 
     Removerter::removeDynamicPointsOfScanByKnn ( int _scan_idx )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // curr scan (in local coord)
     pcl::PointCloud<PointType>::Ptr scan_orig = scans_.at(_scan_idx); 
     auto scan_pose = scan_poses_.at(_scan_idx);
@@ -805,7 +777,6 @@ std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr>
 
 void Removerter::saveStaticScan( int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     std::string file_name_orig;
     std::string file_name;
 
@@ -823,7 +794,6 @@ void Removerter::saveStaticScan( int _scan_idx, const pcl::PointCloud<PointType>
 
 void Removerter::saveDynamicScan( int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     std::string file_name_orig;
     std::string file_name;
 
@@ -841,7 +811,6 @@ void Removerter::saveDynamicScan( int _scan_idx, const pcl::PointCloud<PointType
 
 void Removerter::saveCleanedScans(void)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     if( ! kFlagSaveCleanScans )
         return;
 
@@ -856,7 +825,6 @@ void Removerter::saveCleanedScans(void)
 
 void Removerter::saveMapPointcloudByMergingCleanedScans(void)
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // merge for verification
     if (!kFlagSaveMapPointcloud)
         return;
@@ -917,7 +885,6 @@ void Removerter::saveMapPointcloudByMergingCleanedScans(void)
 
 void Removerter::scansideRemovalForEachScan( void )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // for fast scan-side neighbor search 
     kdtree_map_global_curr_->setInputCloud(map_global_curr_); 
 
@@ -932,7 +899,6 @@ void Removerter::scansideRemovalForEachScan( void )
 
 void Removerter::scansideRemovalForEachScanAndSaveThem( void )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     scansideRemovalForEachScan();
     saveCleanedScans();
     saveMapPointcloudByMergingCleanedScans();
@@ -941,7 +907,6 @@ void Removerter::scansideRemovalForEachScanAndSaveThem( void )
 
 void Removerter::run( void )
 {
-    ROS_DEBUG("%s", __PRETTY_FUNCTION__ );
     // load scan and poses
     parseValidScanInfo();
     readValidScans();

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -126,3 +126,33 @@ float pointDistance(PointType p1, PointType p2)
     return sqrt((p1.x-p2.x)*(p1.x-p2.x) + (p1.y-p2.y)*(p1.y-p2.y) + (p1.z-p2.z)*(p1.z-p2.z));
 }
 
+Eigen::Matrix4d readPose(const std::string& filename) {
+    int col = 0;
+    double buff[16];
+    std::ifstream file(filename);
+    if (file.is_open()) {
+        std::string line;
+        // Skip the two first lines
+        for (int i = 0; i < 2; i++)
+            file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        // Read matrix
+        for (int row = 0; getline(file, line) && row < 4; ++row) {
+            std::stringstream stream(line);
+            int temp_col = 0;
+            while(! stream.eof())
+                stream >> buff[col*row+temp_col++];
+            if (col == 0)
+                col = temp_col;
+        }
+    } else {
+        ROS_ERROR("Wrong file path");
+    }
+    file.close();
+    // Populate matrix with numbers
+    Eigen::Matrix4d matrix(4, 4);
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            matrix(i, j) = buff[col * i + j];
+    return matrix;
+}
+


### PR DESCRIPTION
Hi! Thank you for this awesome project!

I have added a new format support for removing dynamic points from clouds built with [**_hdl_graph_slam_**](https://github.com/koide3/hdl_graph_slam). 
New yaml file was added for hdl_graph_slam format. 
Before running removert you need to [_dump_](https://github.com/koide3/hdl_graph_slam#services) all the internal data.

I have also slightly improved the performance of the code.
This branch was tested with the different data formats, it works the same perfect way.

So, to run the *Removert*:
```
$ roslaunch removert run_hdl_graph_slam.launch # if you use hdl_graph_slam dump 
or
$ roslaunch removert run_kitti.launch # if you use KITTI dataset 
 or
$ roslaunch removert run_scliosam.launch # see this tutorial: https://youtu.be/UiYYrPMcIRU
```

**Some results:**
**1.** _Before removert_
![Screenshot from 2022-01-20 02-10-17](https://user-images.githubusercontent.com/21182465/150237414-872f77fc-b7cc-4269-b650-8af5c0ee8070.png)

_After_
![Screenshot from 2022-01-20 02-13-16](https://user-images.githubusercontent.com/21182465/150237490-8a2908e2-ea93-4473-a68d-095d66ec3ec8.png)

**2.** _Before removert_
![Screenshot from 2022-01-20 02-16-50](https://user-images.githubusercontent.com/21182465/150237648-7e53295c-a2df-4416-a84d-65847ee2268d.png)

_After_
![Screenshot from 2022-01-20 02-17-33](https://user-images.githubusercontent.com/21182465/150237661-5a2c73e7-970d-436d-bbfe-c6174604fb50.png)



